### PR TITLE
Improve screen reader status updates

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
   <input type="text" id="hashInput" placeholder="ハッシュ値を入力してください">
 
   <div id="result" aria-live="polite"></div>
+  <div id="message" role="status" aria-live="polite" class="visually-hidden"></div>
 
   <h2>🧪 テスト用ハッシュ一覧</h2>
   <ul>

--- a/script.js
+++ b/script.js
@@ -53,12 +53,25 @@ function setHash(el) {
   identifyHash();
 }
 
+function showMessage(text) {
+  const messageEl = document.getElementById('message');
+  if (messageEl) {
+    // Clear previous message to ensure screen readers announce updates
+    messageEl.textContent = '';
+    setTimeout(() => {
+      messageEl.textContent = text;
+    }, 0);
+  }
+}
+
 function copyHash() {
   const hash = document.getElementById('hashInput').value.trim();
   navigator.clipboard.writeText(hash).then(() => {
     alert("ハッシュをコピーしました！");
+    showMessage('ハッシュをコピーしました！');
   }).catch(err => {
     alert("コピーに失敗しました：" + err);
+    showMessage('コピーに失敗しました: ' + err);
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -35,3 +35,17 @@ code {
 code:hover {
   background: #e0e0e0;
 }
+
+/* Screen reader only text */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add offscreen `.visually-hidden` class
- expose #message region with `role="status"` and `aria-live`
- implement `showMessage()` for screen reader announcements
- use `showMessage()` when copying hashes

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684ffd812d98832b8fcea7f61d61e947