### PR TITLE
Add z-index to message notification

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <input type="text" id="hashInput" placeholder="ハッシュ値を入力してください">
 
   <div id="result" aria-live="polite"></div>
-  <div id="message" role="status" aria-live="polite" class="visually-hidden"></div>
+  <div id="message" role="status" aria-live="polite" class="visually-hidden message"></div>
 
   <h2>🧪 テスト用ハッシュ一覧</h2>
   <ul>

--- a/style.css
+++ b/style.css
@@ -49,3 +49,8 @@ code:hover {
   white-space: nowrap;
   border: 0;
 }
+
+/* Notification styling */
+.message {
+  z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- ensure the message container uses the `message` class
- give `.message` a `z-index` so it floats above the page

## Testing
- `grep -n z-index style.css`

------
https://chatgpt.com/codex/tasks/task_e_684ffe436b28832bb177c3780d4446b2